### PR TITLE
Overrided code class to resolve borders occuring for every line of code highlight

### DIFF
--- a/src/css/prism.less
+++ b/src/css/prism.less
@@ -20,6 +20,10 @@
   position: relative;
 }
 
+// Overrided this class to remove borders occuring for each line within code highlight.
+.prism code {
+  box-shadow: none !important;
+}
 
 
 


### PR DESCRIPTION
<img width="1680" alt="Screenshot 2020-08-20 at 12 41 49 AM" src="https://user-images.githubusercontent.com/16250634/90679578-fe180d80-e27d-11ea-9200-1a186a533495.png">

Now border lines will not occur for every line of code.